### PR TITLE
Strip leading zeros

### DIFF
--- a/semver2.sh
+++ b/semver2.sh
@@ -140,17 +140,17 @@ semver_compare() {
   version_b=$(printf %s "$secondParam" | cut -d'+' -f 1)
   version_b=$(removeLeadingV "$version_b")
 
-  a_major=$(printf %s "$version_a" | cut -d'.' -f 1)
-  a_minor=$(printf %s "$version_a" | cut -d'.' -f 2)
-  a_patch=$(printf %s "$version_a" | cut -d'.' -f 3 | cut -d'-' -f 1)
+  a_major=$(printf %s "$version_a" | cut -d'.' -f 1 | bc)
+  a_minor=$(printf %s "$version_a" | cut -d'.' -f 2 | bc)
+  a_patch=$(printf %s "$version_a" | cut -d'.' -f 3 | cut -d'-' -f 1 | bc)
   a_pre=""
   if [ "$(includesString "$version_a" -)" = 1 ]; then
     a_pre=$(printf %s"${version_a#$a_major.$a_minor.$a_patch-}")
   fi
 
-  b_major=$(printf %s "$version_b" | cut -d'.' -f 1)
-  b_minor=$(printf %s "$version_b" | cut -d'.' -f 2)
-  b_patch=$(printf %s "$version_b" | cut -d'.' -f 3 | cut -d'-' -f 1)
+  b_major=$(printf %s "$version_b" | cut -d'.' -f 1 | bc)
+  b_minor=$(printf %s "$version_b" | cut -d'.' -f 2 | bc)
+  b_patch=$(printf %s "$version_b" | cut -d'.' -f 3 | cut -d'-' -f 1 | bc)
   b_pre=""
   if [ "$(includesString "$version_b" -)" = 1 ]; then
     b_pre=$(printf %s"${version_b#$b_major.$b_minor.$b_patch-}")

--- a/test.sh
+++ b/test.sh
@@ -9,6 +9,8 @@ source ./semver2.sh 1.0.0 1.0.0
 # spec 11.4
 # 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
 tests=(
+  0.01.9
+  00.2.0
   1.0.0-0--1
   1.0.0-0-0
   1.0.0-0-0.alpha
@@ -23,6 +25,8 @@ tests=(
   1.0.0+metadata.0.0.0
   2.0.0-ALPHA
   2.0.0-alpha
+  18.04.1
+  18.09.1
 )
 
 # others


### PR DESCRIPTION
Hi — thanks for writing this lovely tool. 

While using it I found an interesting bug while comparing different versions of Docker:

```
→ ./semver2.sh 18.09.1 18.04.1 debug
./semver2.sh: line 83: 04 - 09: value too great for base (error token is "09")
DEBUG: Detected: 18 09 1 identifiers:  
DEBUG: Detected: 18 04 1 identifiers:  
DEBUG: MAJOR are equal 
DEBUG: MINOR is different 
```

Essentially the error occurs because the shell interprets numbers with a leading zero as (poorly formed) octals — example using bash 3 in posix mode:

```
$ echo $BASH_VERSION
3.2.57(1)-release

$ echo $((04 - 09))
sh: 04 - 09: value too great for base (error token is "09")

$ echo $((0x4 - 0x9))
-5
```

I'd like to suggest a fix — after a little bit of poking on [SO](https://stackoverflow.com/questions/19861394/stripping-leading-zeros-using-bash-substring-removal-only) I think the simplest solution to stripping the leading zeroes might be to just pipe to `bc`