### PR TITLE
fix: Fix shellcheck issues

### DIFF
--- a/semver2.sh
+++ b/semver2.sh
@@ -114,7 +114,7 @@ compareString() {
 includesString() {
   string="$1"
   substring="$2"
-  if [ "${string#*$substring}" != "$string" ]
+  if [ "${string#*"$substring"}" != "$string" ]
   then
     printf "1"
     return 1    # $substring is in $string
@@ -156,7 +156,7 @@ semver_compare() {
   a_patch=$(printf %s "$version_a" | cut -d'.' -f 3 | cut -d'-' -f 1)
   a_pre=""
   if [ "$(includesString "$version_a" -)" = 1 ]; then
-    a_pre=$(printf %s"${version_a#$a_major.$a_minor.$a_patch-}")
+    a_pre=$(printf %s"${version_a#"$a_major.$a_minor.$a_patch-"}")
   fi
 
   b_major=$(printf %s "$version_b" | cut -d'.' -f 1)
@@ -164,7 +164,7 @@ semver_compare() {
   b_patch=$(printf %s "$version_b" | cut -d'.' -f 3 | cut -d'-' -f 1)
   b_pre=""
   if [ "$(includesString "$version_b" -)" = 1 ]; then
-    b_pre=$(printf %s"${version_b#$b_major.$b_minor.$b_patch-}")
+    b_pre=$(printf %s"${version_b#"$b_major.$b_minor.$b_patch-"}")
   fi
 
   a_major=$(normalizeZero "$a_major")


### PR DESCRIPTION
Fix shellcheck issues

```
$ shellcheck semver2.sh 

In semver2.sh line 117:
  if [ "${string#*$substring}" != "$string" ]
                  ^--------^ SC2295 (info): Expansions inside ${..} need to be quoted separately, otherwise they match as patterns.

Did you mean: 
  if [ "${string#*"$substring"}" != "$string" ]


In semver2.sh line 159:
    a_pre=$(printf %s"${version_a#$a_major.$a_minor.$a_patch-}")
                                  ^------^ SC2295 (info): Expansions inside ${..} need to be quoted separately, otherwise they match as patterns.
                                           ^------^ SC2295 (info): Expansions inside ${..} need to be quoted separately, otherwise they match as patterns.
                                                    ^------^ SC2295 (info): Expansions inside ${..} need to be quoted separately, otherwise they match as patterns.

Did you mean: 
    a_pre=$(printf %s"${version_a#"$a_major"."$a_minor"."$a_patch"-}")


In semver2.sh line 167:
    b_pre=$(printf %s"${version_b#$b_major.$b_minor.$b_patch-}")
                                  ^------^ SC2295 (info): Expansions inside ${..} need to be quoted separately, otherwise they match as patterns.
                                           ^------^ SC2295 (info): Expansions inside ${..} need to be quoted separately, otherwise they match as patterns.
                                                    ^------^ SC2295 (info): Expansions inside ${..} need to be quoted separately, otherwise they match as patterns.

Did you mean: 
    b_pre=$(printf %s"${version_b#"$b_major"."$b_minor"."$b_patch"-}")

For more information:
  https://www.shellcheck.net/wiki/SC2295 -- Expansions inside ${..} need to b...

```